### PR TITLE
[docs fix] 修复在线阅读内容

### DIFF
--- a/docs/tips/source-code-reading-skills.md
+++ b/docs/tips/source-code-reading-skills.md
@@ -53,9 +53,9 @@ public interface BeanDefinition extends AttributeAccessor, BeanMetadataElement {
 
 | 使用频率   | 相关快捷键                               |
 | ---------- | ---------------------------------------- |
-| ⭐⭐⭐⭐⭐ | `Ctrl + N` (Win) / `Command + O` （Mac） |
+| ⭐⭐⭐⭐⭐ | `Ctrl + N` (Win) / `Command + ○` （Mac） |
 
-使用快捷键 `Ctrl + N` (Win) / `Command + O` （Mac）可以快速检索类/文件。
+使用快捷键 `Ctrl + N` (Win) / `Command + ○` （Mac）可以快速检索类/文件。
 
 ![](https://guide-blog-images.oss-cn-shenzhen.aliyuncs.com/idea/20210527135629367.png)
 


### PR DESCRIPTION
在阅读过程中，大 O（哦）容易看成 0（零），所以改成了圆圈，但改了之后有点违和感，看 Guide 哥是否采纳~